### PR TITLE
Add support for LXD virtual-machine type images

### DIFF
--- a/builder/lxd/config.go
+++ b/builder/lxd/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	// List of key/value pairs you wish to
 	// pass to lxc launch via --config. Defaults to empty.
 	LaunchConfig map[string]string `mapstructure:"launch_config" required:"false"`
+	// Create LXD virtual-machine image; defaults to false for container image
+	VirtualMachine bool `mapstructure:"virtual_machine"`
 
 	ctx interpolate.Context
 }

--- a/builder/lxd/config.hcl2spec.go
+++ b/builder/lxd/config.hcl2spec.go
@@ -26,6 +26,7 @@ type FlatConfig struct {
 	InitSleep           *string           `mapstructure:"init_sleep" required:"false" cty:"init_sleep" hcl:"init_sleep"`
 	PublishProperties   map[string]string `mapstructure:"publish_properties" required:"false" cty:"publish_properties" hcl:"publish_properties"`
 	LaunchConfig        map[string]string `mapstructure:"launch_config" required:"false" cty:"launch_config" hcl:"launch_config"`
+	VirtualMachine      *string           `mapstructure:"virtual_machine" cty:"virtual_machine" hcl:"virtual_machine"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -56,6 +57,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"init_sleep":                 &hcldec.AttrSpec{Name: "init_sleep", Type: cty.String, Required: false},
 		"publish_properties":         &hcldec.AttrSpec{Name: "publish_properties", Type: cty.Map(cty.String), Required: false},
 		"launch_config":              &hcldec.AttrSpec{Name: "launch_config", Type: cty.Map(cty.String), Required: false},
+		"virtual_machine":            &hcldec.AttrSpec{Name: "virtual_machine", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/lxd/config.hcl2spec.go
+++ b/builder/lxd/config.hcl2spec.go
@@ -26,7 +26,7 @@ type FlatConfig struct {
 	InitSleep           *string           `mapstructure:"init_sleep" required:"false" cty:"init_sleep" hcl:"init_sleep"`
 	PublishProperties   map[string]string `mapstructure:"publish_properties" required:"false" cty:"publish_properties" hcl:"publish_properties"`
 	LaunchConfig        map[string]string `mapstructure:"launch_config" required:"false" cty:"launch_config" hcl:"launch_config"`
-	VirtualMachine      *string           `mapstructure:"virtual_machine" cty:"virtual_machine" hcl:"virtual_machine"`
+	VirtualMachine      *bool             `mapstructure:"virtual_machine" cty:"virtual_machine" hcl:"virtual_machine"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -57,7 +57,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"init_sleep":                 &hcldec.AttrSpec{Name: "init_sleep", Type: cty.String, Required: false},
 		"publish_properties":         &hcldec.AttrSpec{Name: "publish_properties", Type: cty.Map(cty.String), Required: false},
 		"launch_config":              &hcldec.AttrSpec{Name: "launch_config", Type: cty.Map(cty.String), Required: false},
-		"virtual_machine":            &hcldec.AttrSpec{Name: "virtual_machine", Type: cty.String, Required: false},
+		"virtual_machine":            &hcldec.AttrSpec{Name: "virtual_machine", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/lxd/step_lxd_launch.go
+++ b/builder/lxd/step_lxd_launch.go
@@ -17,12 +17,6 @@ func (s *stepLxdLaunch) Run(ctx context.Context, state multistep.StateBag) multi
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	if ! config.VirtualMachine {
-		config.VirtualMachine = false
-	} else {
-		config.VirtualMachine = true
-	}
-
 	name := config.ContainerName
 	image := config.Image
 	profile := fmt.Sprintf("--profile=%s", config.Profile)

--- a/builder/lxd/step_lxd_launch.go
+++ b/builder/lxd/step_lxd_launch.go
@@ -17,12 +17,19 @@ func (s *stepLxdLaunch) Run(ctx context.Context, state multistep.StateBag) multi
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packersdk.Ui)
 
+	if ! config.VirtualMachine {
+		config.VirtualMachine = false
+	} else {
+		config.VirtualMachine = true
+	}
+
 	name := config.ContainerName
 	image := config.Image
 	profile := fmt.Sprintf("--profile=%s", config.Profile)
+	vm := fmt.Sprintf("--vm=%s", strconv.FormatBool(config.VirtualMachine))
 
 	launch_args := []string{
-		"launch", "--ephemeral=false", profile, image, name,
+		"launch", "--ephemeral=false", vm, profile, image, name,
 	}
 
 	for k, v := range config.LaunchConfig {

--- a/docs-partials/builder/lxd/Config-not-required.mdx
+++ b/docs-partials/builder/lxd/Config-not-required.mdx
@@ -23,6 +23,6 @@
 - `launch_config` (map[string]string) - List of key/value pairs you wish to
   pass to lxc launch via --config. Defaults to empty.
 
-- `virtual_machine` (string) - Create LXD virtual-machine image; defaults to false for container image
+- `virtual_machine` (bool) - Create LXD virtual-machine image; defaults to false for container image
 
 <!-- End of code generated from the comments of the Config struct in builder/lxd/config.go; -->

--- a/docs-partials/builder/lxd/Config-not-required.mdx
+++ b/docs-partials/builder/lxd/Config-not-required.mdx
@@ -23,4 +23,6 @@
 - `launch_config` (map[string]string) - List of key/value pairs you wish to
   pass to lxc launch via --config. Defaults to empty.
 
+- `virtual_machine` (string) - Create LXD virtual-machine image; defaults to false for container image
+
 <!-- End of code generated from the comments of the Config struct in builder/lxd/config.go; -->

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.0.1"
+	Version = "0.0.2"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Virtual machines are natively supported by LXD starting from version [4.0](https://discuss.linuxcontainers.org/t/running-virtual-machines-with-lxd-4-0/7519)

This PR adds an option to create image type `VIRTUAL-MACHINE` if `true`; defaults to `false` for `CONTAINER`.