### PR TITLE
Update docs to reference config partials

### DIFF
--- a/builder/lxd/config.go
+++ b/builder/lxd/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	// List of key/value pairs you wish to
 	// pass to lxc launch via --config. Defaults to empty.
 	LaunchConfig map[string]string `mapstructure:"launch_config" required:"false"`
-	// Create LXD virtual-machine image; defaults to false for container image
+	// Create LXD virtual-machine image on hosts running LXD 4.0 and above; defaults to false for container image
 	VirtualMachine bool `mapstructure:"virtual_machine"`
 
 	ctx interpolate.Context

--- a/docs-partials/builder/lxd/Config-not-required.mdx
+++ b/docs-partials/builder/lxd/Config-not-required.mdx
@@ -23,6 +23,6 @@
 - `launch_config` (map[string]string) - List of key/value pairs you wish to
   pass to lxc launch via --config. Defaults to empty.
 
-- `virtual_machine` (bool) - Create LXD virtual-machine image; defaults to false for container image
+- `virtual_machine` (bool) - Create LXD virtual-machine image on hosts running LXD 4.0 and above; defaults to false for container image
 
 <!-- End of code generated from the comments of the Config struct in builder/lxd/config.go; -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # LXD Plugin
 
-The LXD plugin allows building containers for LXD. The plugin contains a single builder [lxd](/docs/builders/lxd.mdx), 
+The LXD plugin allows building containers for LXD. The plugin contains a single builder [lxd](/docs/builders/lxd.mdx),
 which starts an LXD container, runs provisioners within this container, then saves the container
 as an LXD image.
 

--- a/docs/builders/lxd.mdx
+++ b/docs/builders/lxd.mdx
@@ -46,9 +46,7 @@ Below is a fully functioning example.
 
 ### Required:
 
-- `image` (string) - The source image to use when creating the build
-  container. This can be a (local or remote) image (name or fingerprint).
-  E.G. `my-base-image`, `ubuntu-daily:x`, `08fababf6f27`, ...
+@include 'builder/lxd/Config-required.mdx'
 
   ~> Note: The builder may appear to pause if required to download a
   remote image, as they are usually 100-200MB. `/var/log/lxd/lxd.log` will
@@ -56,26 +54,4 @@ Below is a fully functioning example.
 
 ### Optional:
 
-- `init_sleep` (string) - The number of seconds to sleep between launching
-  the LXD instance and provisioning it; defaults to 3 seconds.
-
-- `name` (string) - Name of the builder. Defaults to `lxd`.
-
-- `container_name` (string) - Name of the build container.
-  Defaults to `packer-$name`.
-
-- `profile` - Name of the LXD profile used for the build container.
-  Defaults to `default`.
-
-- `output_image` (string) - The name of the output artifact. Defaults to
-  `name`.
-
-- `command_wrapper` (string) - Lets you prefix all builder commands, such as
-  with `ssh` for a remote build host. Defaults to `""`.
-
-- `publish_properties` (map\[string\]string) - Pass key values to the publish
-  step to be set as properties on the output image. This is most helpful to
-  set the description, but can be used to set anything needed. See [here](https://stgraber.org/2016/03/30/lxd-2-0-image-management-512/) for more properties.
-
-- `launch_config` (map\[string\]string) - List of key/value pairs you wish to
-  pass to `lxc launch` via `--config`. Defaults to empty.
+@include 'builder/lxd/Config-not-required.mdx'


### PR DESCRIPTION
Updates the docs to include the config partials generated by `make generate`. The resulting docs after running `packersdc renderdocs -src docs/` looks like the following image. 
<img width="985" alt="Screen Shot 2021-05-25 at 11 30 45 AM" src="https://user-images.githubusercontent.com/1749304/119525884-e1e55780-bd4c-11eb-9127-b2362a431aad.png">
