### PR TITLE
Add optional variable to publish to LXD remote

### DIFF
--- a/builder/lxd/config.go
+++ b/builder/lxd/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	// name.
 	OutputImage   string `mapstructure:"output_image" required:"false"`
 	ContainerName string `mapstructure:"container_name"`
+	// The (optional) name of the LXD remote on which to publish the
+	// container image.
+	PublishRemote string `mapstructure:"publish_remote" required:"false"`
 	// Lets you prefix all builder commands, such as
 	// with ssh for a remote build host. Defaults to `{{.Command}}`; i.e. no
 	// wrapper.

--- a/builder/lxd/config.hcl2spec.go
+++ b/builder/lxd/config.hcl2spec.go
@@ -20,6 +20,7 @@ type FlatConfig struct {
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
 	OutputImage         *string           `mapstructure:"output_image" required:"false" cty:"output_image" hcl:"output_image"`
 	ContainerName       *string           `mapstructure:"container_name" cty:"container_name" hcl:"container_name"`
+	PublishRemote       *string           `mapstructure:"publish_remote" required:"false" cty:"publish_remote" hcl:"publish_remote"`
 	CommandWrapper      *string           `mapstructure:"command_wrapper" required:"false" cty:"command_wrapper" hcl:"command_wrapper"`
 	Image               *string           `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
 	Profile             *string           `mapstructure:"profile" cty:"profile" hcl:"profile"`
@@ -50,6 +51,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"output_image":               &hcldec.AttrSpec{Name: "output_image", Type: cty.String, Required: false},
+        "publish_remote":             &hcldec.AttrSpec{Name: "publish_remote", Type: cty.String, Required: false},
 		"container_name":             &hcldec.AttrSpec{Name: "container_name", Type: cty.String, Required: false},
 		"command_wrapper":            &hcldec.AttrSpec{Name: "command_wrapper", Type: cty.String, Required: false},
 		"image":                      &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},

--- a/builder/lxd/step_publish.go
+++ b/builder/lxd/step_publish.go
@@ -12,6 +12,9 @@ import (
 type stepPublish struct{}
 
 func (s *stepPublish) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+
+	var remote string = ""
+
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packersdk.Ui)
 
@@ -30,8 +33,12 @@ func (s *stepPublish) Run(ctx context.Context, state multistep.StateBag) multist
 		return multistep.ActionHalt
 	}
 
+	if config.PublishRemote != "" {
+		remote = config.PublishRemote + ":"
+	}
+
 	publish_args := []string{
-		"publish", name, "--alias", config.OutputImage,
+		"publish", name, remote, "--alias", config.OutputImage,
 	}
 
 	for k, v := range config.PublishProperties {
@@ -56,5 +63,6 @@ func (s *stepPublish) Run(ctx context.Context, state multistep.StateBag) multist
 
 	return multistep.ActionContinue
 }
+
 
 func (s *stepPublish) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
This PR addresses issue #25
Closes #25

An additional, optional configuration parameter `publish_remote` is added which, if set, specifies the LXD remote on which to publish the output image.

For example, if the parameter is set as `remote_publish: "remote-name"`, then the output image is published with the command `lxc publish container-name remote-name: --alias output-image`.

If the parameter is not set, then the output image is published, as before, with the command `lxc publish container-name --alias output-image`.

Contrary to one of my suggestions in issue #25, I have **not** added a parameter specifying the LXD remote for the launch/build step, since this can be achieved by adding the LXD remote directly in the existing parameter `container_name`, for example as `container_name = "remote-name:container-name"`.