### PR TITLE
Add optional value skip_publish

### DIFF
--- a/builder/lxd/config.go
+++ b/builder/lxd/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	LaunchConfig map[string]string `mapstructure:"launch_config" required:"false"`
 	// Create LXD virtual-machine image on hosts running LXD 4.0 and above; defaults to false for container image
 	VirtualMachine bool `mapstructure:"virtual_machine"`
+	// Skip execute `lxc publish`; defaults to false
+	SkipPublish bool `mapstructure:"skip_publish" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/lxd/config.hcl2spec.go
+++ b/builder/lxd/config.hcl2spec.go
@@ -27,6 +27,7 @@ type FlatConfig struct {
 	PublishProperties   map[string]string `mapstructure:"publish_properties" required:"false" cty:"publish_properties" hcl:"publish_properties"`
 	LaunchConfig        map[string]string `mapstructure:"launch_config" required:"false" cty:"launch_config" hcl:"launch_config"`
 	VirtualMachine      *bool             `mapstructure:"virtual_machine" cty:"virtual_machine" hcl:"virtual_machine"`
+	SkipPublish         *bool             `mapstructure:"skip_publish" required:"false" cty:"skip_publish" hcl:"skip_publish"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -58,6 +59,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"publish_properties":         &hcldec.AttrSpec{Name: "publish_properties", Type: cty.Map(cty.String), Required: false},
 		"launch_config":              &hcldec.AttrSpec{Name: "launch_config", Type: cty.Map(cty.String), Required: false},
 		"virtual_machine":            &hcldec.AttrSpec{Name: "virtual_machine", Type: cty.Bool, Required: false},
+		"skip_publish":               &hcldec.AttrSpec{Name: "skip_publish", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/lxd/step_publish.go
+++ b/builder/lxd/step_publish.go
@@ -15,6 +15,11 @@ func (s *stepPublish) Run(ctx context.Context, state multistep.StateBag) multist
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packersdk.Ui)
 
+	if config.SkipPublish {
+		ui.Say("skip_publish is true. Skipping step for publish")
+		return multistep.ActionContinue
+	}
+
 	name := config.ContainerName
 	stop_args := []string{
 		// We created the container with "--ephemeral=false" so we know it is safe to stop.

--- a/docs-partials/builder/lxd/Config-not-required.mdx
+++ b/docs-partials/builder/lxd/Config-not-required.mdx
@@ -25,4 +25,6 @@
 
 - `virtual_machine` (bool) - Create LXD virtual-machine image on hosts running LXD 4.0 and above; defaults to false for container image
 
+- `skip_publish` (bool) - Skip execute `lxc publish`; defaults to false
+
 <!-- End of code generated from the comments of the Config struct in builder/lxd/config.go; -->


### PR DESCRIPTION
Closes #36 

This change adds `skip_publish`, It becomes no execute `lxc publish` if true.

Please read the background to #36.