### PR TITLE
fix: Do not create base folder on remote when uploading dir

### DIFF
--- a/builder/lxd/communicator.go
+++ b/builder/lxd/communicator.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -92,7 +93,10 @@ func (c *Communicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
 
 func (c *Communicator) UploadDir(dst string, src string, exclude []string) error {
 	fileDestination := fmt.Sprintf("%s/%s", c.ContainerName, dst)
-	pushCommand := fmt.Sprintf("lxc file push --debug -pr %s %s", src, fileDestination)
+	if !strings.HasSuffix(src, "/") {
+		src += "/"
+	}
+	pushCommand := fmt.Sprintf("lxc file push --debug -pr %s* %s", src, fileDestination)
 	log.Printf(pushCommand)
 	cp, err := c.CmdWrapper(pushCommand)
 	if err != nil {


### PR DESCRIPTION
Calling lxc files push dir/ instance:/tmp/abc will create folder /tmp/abc/dir with all files inside which does not match behavior expected by Packer - files should be placed directly under /tmp/abc.

Use lxc files push dir/* to upload files to proper directory

Closes #7

