### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-lxd
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/hcl/v2 v2.13.0


### PR DESCRIPTION
- Upgrade plugin for integrations library
- docs: update readmes and metadata.hcl
- docs: fix initialization/init section
- go.mod: bump go version from 1.18 to 1.19
