### PR TITLE
makefile: remove old docs targets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,10 +20,6 @@ test:
 install-packer-sdc: ## Install packer sofware development command
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-packer-sdc
-	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
-	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
-
 plugin-check: install-packer-sdc build
 	@packer-sdc plugin-check ${BINARY}
 
@@ -34,9 +30,7 @@ generate: install-packer-sdc
 	@go generate ./...
 	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
 	# checkout the .docs folder for a preview of the docs
-
-build-docs: install-packer-sdc
-	@if [ -d ".docs" ]; then rm -r ".docs"; fi
+	@rm -rf .docs
 	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
 	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "hashicorp"
 	@rm -r ".docs"


### PR DESCRIPTION
Since we moved the docs to integrations, we don't need to build the
docs.zip file anymore, and to make it easier for plugin developers we
move the logic for building the new .docs directory to the `generate'
Makefile target.
