### PR TITLE
Add instance_id to state so ID is usable in provisioners

### DIFF
--- a/builder/lxd/step_lxd_launch.go
+++ b/builder/lxd/step_lxd_launch.go
@@ -54,6 +54,10 @@ func (s *stepLxdLaunch) Run(ctx context.Context, state multistep.StateBag) multi
 
 	time.Sleep(time.Duration(sleep_seconds) * time.Second)
 	log.Printf("Sleeping for %d seconds...", sleep_seconds)
+	// instance_id is the generic term used so that users can have access to the
+	// instance id inside the provisioners, used in step_provision.
+	state.Put("instance_id", name)
+	ui.Message(fmt.Sprintf("Instance Name: %s", name))
 	return multistep.ActionContinue
 }
 

--- a/builder/lxd/step_lxd_launch.go
+++ b/builder/lxd/step_lxd_launch.go
@@ -52,8 +52,9 @@ func (s *stepLxdLaunch) Run(ctx context.Context, state multistep.StateBag) multi
 	// TODO: Should we check `lxc info <container>` for "Running"?
 	// We have to do this so /tmp doesn't get cleared and lose our provisioner scripts.
 
-	time.Sleep(time.Duration(sleep_seconds) * time.Second)
 	log.Printf("Sleeping for %d seconds...", sleep_seconds)
+	time.Sleep(time.Duration(sleep_seconds) * time.Second)
+
 	// instance_id is the generic term used so that users can have access to the
 	// instance id inside the provisioners, used in step_provision.
 	state.Put("instance_id", name)

--- a/builder/lxd/step_lxd_launch.go
+++ b/builder/lxd/step_lxd_launch.go
@@ -33,17 +33,18 @@ func (s *stepLxdLaunch) Run(ctx context.Context, state multistep.StateBag) multi
 		launch_args = append(launch_args, "--config", fmt.Sprintf("%s=%s", k, v))
 	}
 
-	ui.Say("Creating container...")
-	_, err := LXDCommand(launch_args...)
+	sleep_seconds, err := strconv.Atoi(config.InitSleep)
 	if err != nil {
-		err := fmt.Errorf("Error creating container: %s", err)
+		err := fmt.Errorf("Error parsing InitSleep into int: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
-	sleep_seconds, err := strconv.Atoi(config.InitSleep)
+
+	ui.Say("Creating container...")
+	_, err = LXDCommand(launch_args...)
 	if err != nil {
-		err := fmt.Errorf("Error parsing InitSleep into int: %s", err)
+		err := fmt.Errorf("Error creating container: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt


### PR DESCRIPTION
Hi,

The change I'm proposing should be pretty straightforward but I'm having difficulty testing it as `packer` is not picking up my locally built plugin and keep using the "official" one. Also the content of the linked CONTRIBUTING.md file seems sort of not updated.

https://github.com/hashicorp/packer-plugin-lxd/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

Any pointers would be welcome on this 🙏 