### PR TITLE
GNUmakefile: make dev uses packer for install

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 NAME=lxd
 BINARY=packer-plugin-${NAME}
+PLUGIN_FQN="$(shell grep -E '^module' <go.mod | sed -E 's/module *//')"
 
 COUNT?=1
 TEST?=$(shell go list ./...)
@@ -10,9 +11,9 @@ HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/pac
 build:
 	@go build -o ${BINARY}
 
-dev: build
-	@mkdir -p ~/.packer.d/plugins/
-	@mv ${BINARY} ~/.packer.d/plugins/${BINARY}
+dev:
+	@go build -ldflags="-X '${PLUGIN_FQN}/version.VersionPrerelease=dev'" -o '${BINARY}'
+	packer plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
 
 test:
 	@go test -race -count $(COUNT) $(TEST) -timeout=3m


### PR DESCRIPTION
When building the development version of the plugin, we now use
`packer plugins install` for that instead of moving it to the plugins
directory manually.

This target will require Packer 1.10.2 and above to function, as prior
versions don't support instaling pre-release versions of a plugin with
that command.
