### PR TITLE
BUG: Fixed a bug in UploadDir logic

### DIFF
--- a/builder/lxd/communicator.go
+++ b/builder/lxd/communicator.go
@@ -93,10 +93,15 @@ func (c *Communicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
 
 func (c *Communicator) UploadDir(dst string, src string, exclude []string) error {
 	fileDestination := fmt.Sprintf("%s/%s", c.ContainerName, dst)
-	if !strings.HasSuffix(src, "/") {
-		src += "/"
+
+	pushCommand := ""
+
+	if strings.HasSuffix(src, "/") {
+		pushCommand = fmt.Sprintf("lxc file push --debug -pr %s* %s", src, fileDestination)
+	} else {
+		pushCommand = fmt.Sprintf("lxc file push --debug -pr %s %s", src, fileDestination)
 	}
-	pushCommand := fmt.Sprintf("lxc file push --debug -pr %s* %s", src, fileDestination)
+
 	log.Printf(pushCommand)
 	cp, err := c.CmdWrapper(pushCommand)
 	if err != nil {


### PR DESCRIPTION
Currently, the `UploadDir` method's logic does not align with Packer's documentation which says:
```
If the source is /foo (no trailing slash), and the destination is /tmp, then the contents of /foo on the local
machine will be uploaded to /tmp/foo on the remote machine. The foo directory on the remote machine
will be created by Packer.
```

This fixes that.

Closes https://github.com/hashicorp/packer/issues/13393