### PR TITLE
[builder] error handling for type assertion

### DIFF
--- a/builder/lxd/builder.go
+++ b/builder/lxd/builder.go
@@ -5,6 +5,7 @@ package lxd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -66,7 +67,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	id := "0"
 	if !b.config.SkipPublish {
-		id = state.Get("imageFingerprint").(string)
+		maybeId, ok := state.Get("imageFingerprint").(string)
+		if !ok {
+			return nil, fmt.Errorf("Failed to read imageFingerprint")
+		}
+		id = maybeId
+
 	}
 
 	artifact := &Artifact{


### PR DESCRIPTION
### Description
What code changed, and why?
Adds error handling for a failed type assertion.
The failure happens if you Ctrl+C early enough in the packer build run.

### Resolved Issues
Fixes https://github.com/hashicorp/packer/issues/12763

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan
If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

no

